### PR TITLE
Create hash function class

### DIFF
--- a/src/utils/shortener.ts
+++ b/src/utils/shortener.ts
@@ -1,0 +1,14 @@
+export class Shortener {
+    public shorten(url: string): string {
+        if (!url) {
+            throw new Error('URL not supplied');
+        }
+
+        // TODO: enhance URL validation
+        if (!url.match(/^http/)) {
+            throw new Error('Invalid URL supplied');
+        }
+
+        return 'cafe12';
+    }
+}

--- a/test/shortener.test.ts
+++ b/test/shortener.test.ts
@@ -1,0 +1,33 @@
+import { Shortener } from '../src/utils/shortener';
+let shortener: Shortener;
+
+describe('Shortener', () => {
+    beforeEach(() => {
+        shortener = new Shortener();
+    });
+
+    describe('shorten', () => {
+        it('should throw an error when an invalid URL is supplied', () => {
+            const expectedErrorMsg = 'Invalid URL supplied';
+            const bogusURL1 = 'bogus-string';
+            const bogusURL2 = 'ftp://myhost.com/';
+
+            expect(() => shortener.shorten(bogusURL1)).toThrow(
+                expectedErrorMsg
+            );
+
+            expect(() => shortener.shorten(bogusURL2)).toThrow(
+                expectedErrorMsg
+            );
+
+            // TODO: add additional invalid URLs to test
+        });
+
+        it('should return cafe12 (for now)', () => {
+            const result = shortener.shorten('https://google.com');
+            const expectedResult = 'cafe12';
+
+            expect(result).toEqual(expectedResult);
+        });
+    });
+});


### PR DESCRIPTION
Fixes #4 

Creates a class that generates a hash for URL shortening. All the work is being done in the `utils` and `test` folder.

Start the unit test watcher by typing the following command:

```bash
npm run test:watch
```
